### PR TITLE
Fix: only check if category exist when adding a new category

### DIFF
--- a/client/src/pages/budget/BudgetForm.tsx
+++ b/client/src/pages/budget/BudgetForm.tsx
@@ -50,12 +50,14 @@ function BudgetForm({
   const handleSubmit = () => {
     // validate data
     const result = BudgetFormSchema.safeParse(formData);
+    const isNotEditingCategory =
+      selectedItem?.categoryId !== formData.categoryId;
 
     if (result.success) {
       const { categoryId, amountLimit, month, year } = result.data;
 
       // check if the selected category is already existed
-      if (existingBudgets.includes(categoryId)) {
+      if (isNotEditingCategory && existingBudgets.includes(categoryId)) {
         setErrors({ categoryId: "Category already exists" });
         return;
       }


### PR DESCRIPTION
- update logic to only check for existing categories when adding new category to prevent false validation errors when editing a category